### PR TITLE
rocrate task submission disclaimer

### DIFF
--- a/website/pages/index.mdx
+++ b/website/pages/index.mdx
@@ -1,2 +1,11 @@
+import { Steps,Callout } from "nextra/components"
+
 # Welcome to Federated Analytics 
 We provide tools for federated activities in secure environments.
+
+<Callout type="info"> 
+The documentation provided here is for a demonstration stack.
+Certain functionality is included only to demonstrate the user-interface.
+This includes **RO-Crate Task Submission**, a feature that is no longer planned
+and will be removed from future releases of this stack.  
+</Callout>


### PR DESCRIPTION
I've not had opportunity to remove the RO-Crate task submission instructions, as this would be a major rewrite of the documentation.

Instead I've added a disclaimer to the front page that this documentation for a demonstration stack. Hopefully this will be sufficient until the next release of the stack.

